### PR TITLE
make sure the bitstream is ended with 0xFFFFFFFFF or progfpga would c…

### DIFF
--- a/patch_progfpga.c
+++ b/patch_progfpga.c
@@ -374,6 +374,14 @@ int main(int argc, char **argv)
             }
             break;
          }
+
+         if( Adr == PatchData[BurnType].ImageSize / 4 - 1 && Value != 0xFFFFFFFF ) {
+             printf( "overrided end of bitstream file with 0xFFFFFFFF\n" );
+
+             Value = 0xFFFFFFFF;
+             Adr = 0xFFFFFFFF;
+         }
+
       // Reverse the byte order
          cp1[0] = cp[3];
          cp1[1] = cp[2];


### PR DESCRIPTION
…rash.

The bin file generated by ISE 14.7 (Ubuntu 18.04) doesn't end with 0xFFFFFFFF.